### PR TITLE
feat(grammar): add grammar management CLI (#8)

### DIFF
--- a/src/cli/export.rs
+++ b/src/cli/export.rs
@@ -1,4 +1,4 @@
-//! Vocabulary export in multiple formats.
+//! Vocabulary and grammar export in multiple formats.
 
 use snafu::{ResultExt, ensure};
 
@@ -7,13 +7,21 @@ use crate::{
     error::{self, Result},
 };
 
-/// Export all vocabulary in the specified format to stdout.
-pub async fn export(db: &Database, format: &str) -> Result<()> {
+/// Export vocabulary or grammar in the specified format to stdout.
+pub async fn export(db: &Database, format: &str, grammar: bool) -> Result<()> {
     ensure!(
         matches!(format, "json" | "csv" | "anki"),
         error::UnknownFormatSnafu { format }
     );
 
+    if grammar {
+        export_grammar(db, format).await
+    } else {
+        export_vocabulary(db, format).await
+    }
+}
+
+async fn export_vocabulary(db: &Database, format: &str) -> Result<()> {
     let vocab = db.all_vocabulary().await?;
 
     match format {
@@ -30,6 +38,37 @@ pub async fn export(db: &Database, format: &str) -> Result<()> {
         "anki" => {
             for v in &vocab {
                 println!("{}\t{}  {}", v.word, v.reading, v.meaning);
+            }
+        }
+        _ => unreachable!(),
+    }
+
+    Ok(())
+}
+
+async fn export_grammar(db: &Database, format: &str) -> Result<()> {
+    let items = db.all_grammar(None).await?;
+
+    match format {
+        "json" => {
+            let json = serde_json::to_string_pretty(&items).context(error::JsonSnafu)?;
+            println!("{json}");
+        }
+        "csv" => {
+            println!("pattern,meaning,level,example");
+            for g in &items {
+                println!(
+                    "{},{},{},{}",
+                    g.pattern,
+                    g.meaning,
+                    g.level,
+                    g.example.as_deref().unwrap_or("")
+                );
+            }
+        }
+        "anki" => {
+            for g in &items {
+                println!("{}\t{}", g.pattern, g.meaning);
             }
         }
         _ => unreachable!(),

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -39,12 +39,20 @@ pub enum Command {
         #[arg(long, default_value = "N5")]
         level:   String,
     },
-    /// Record that a word was seen/reviewed
+    /// Manage grammar patterns
+    Grammar {
+        #[command(subcommand)]
+        action: GrammarAction,
+    },
+    /// Record that a word or grammar pattern was seen/reviewed
     Seen {
-        /// The word
+        /// The word or grammar pattern
         word:    String,
         /// Quality: 1 (forgot), 3 (recognized), 5 (instant recall)
         quality: u8,
+        /// Record review for a grammar pattern instead of vocabulary
+        #[arg(long)]
+        grammar: bool,
     },
     /// Show vocabulary or grammar due for review
     Review {
@@ -78,10 +86,37 @@ pub enum Command {
         /// Config value
         value: String,
     },
-    /// Export vocabulary data
+    /// Export vocabulary or grammar data
     Export {
         /// Format: json, csv, anki
-        format: String,
+        format:  String,
+        /// Export grammar instead of vocabulary
+        #[arg(long)]
+        grammar: bool,
+    },
+}
+
+/// Grammar management subcommands.
+#[derive(Subcommand)]
+pub enum GrammarAction {
+    /// Add a new grammar pattern
+    Add {
+        /// Grammar pattern (e.g. "〜ている")
+        pattern: String,
+        /// Meaning description
+        meaning: String,
+        /// JLPT level
+        #[arg(long, default_value = "N5")]
+        level:   String,
+        /// Example sentence
+        #[arg(long)]
+        example: Option<String>,
+    },
+    /// List all grammar patterns
+    List {
+        /// Filter by JLPT level
+        #[arg(long)]
+        level: Option<String>,
     },
 }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -41,6 +41,15 @@ pub struct VocabularyItem {
     pub level:   String,
 }
 
+/// A grammar entry for display or export.
+#[derive(Debug, Serialize)]
+pub struct GrammarItem {
+    pub pattern: String,
+    pub meaning: String,
+    pub level:   String,
+    pub example: Option<String>,
+}
+
 /// An item due for SRS review.
 #[derive(Debug, Serialize)]
 pub struct ReviewItem {
@@ -316,6 +325,76 @@ impl Database {
                 reading,
                 meaning,
                 level,
+            })
+            .collect())
+    }
+
+    /// Insert or update a grammar entry.
+    pub async fn add_grammar(
+        &self,
+        pattern: &str,
+        meaning: &str,
+        level: &str,
+        example: Option<&str>,
+    ) -> Result<()> {
+        sqlx::query(
+            "INSERT OR REPLACE INTO grammar (pattern, meaning, level, example) VALUES (?, ?, ?, ?)",
+        )
+        .bind(pattern)
+        .bind(meaning)
+        .bind(level)
+        .bind(example)
+        .execute(self.pool())
+        .await
+        .context(error::SqlxSnafu)?;
+        Ok(())
+    }
+
+    /// Look up a grammar item's database ID by pattern.
+    pub async fn get_grammar_id(&self, pattern: &str) -> Result<i64> {
+        let row: Option<(i64,)> = sqlx::query_as("SELECT id FROM grammar WHERE pattern = ?")
+            .bind(pattern)
+            .fetch_optional(self.pool())
+            .await
+            .context(error::SqlxSnafu)?;
+
+        row.map(|(id,)| id).ok_or_else(|| {
+            error::GrammarNotFoundSnafu {
+                pattern: pattern.to_string(),
+            }
+            .build()
+        })
+    }
+
+    /// Return all grammar items, optionally filtered by JLPT level.
+    pub async fn all_grammar(&self, level: Option<&str>) -> Result<Vec<GrammarItem>> {
+        let rows: Vec<(String, String, String, Option<String>)> = match level {
+            Some(lvl) => {
+                sqlx::query_as(
+                    "SELECT pattern, meaning, level, example FROM grammar WHERE level = ? ORDER \
+                     BY created_at",
+                )
+                .bind(lvl)
+                .fetch_all(self.pool())
+                .await
+            }
+            None => {
+                sqlx::query_as(
+                    "SELECT pattern, meaning, level, example FROM grammar ORDER BY created_at",
+                )
+                .fetch_all(self.pool())
+                .await
+            }
+        }
+        .context(error::SqlxSnafu)?;
+
+        Ok(rows
+            .into_iter()
+            .map(|(pattern, meaning, level, example)| GrammarItem {
+                pattern,
+                meaning,
+                level,
+                example,
             })
             .collect())
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,6 +14,9 @@ pub enum KotobaError {
     #[snafu(display("word not found: {word}"))]
     WordNotFound { word: String },
 
+    #[snafu(display("grammar not found: {pattern}"))]
+    GrammarNotFound { pattern: String },
+
     #[snafu(display("invalid quality rating: {value} (must be 1, 3, or 5)"))]
     InvalidQuality { value: u8 },
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,9 +30,34 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
             db.add_vocabulary(&word, &reading, &meaning, &level).await?;
             println!("added: {word}({reading}) = {meaning}");
         }
-        Command::Seen { word, quality } => {
-            srs::record_review(&db, &word, quality).await?;
-            println!("recorded review: {word} quality={quality}");
+        Command::Grammar { action } => match action {
+            cli::GrammarAction::Add {
+                pattern,
+                meaning,
+                level,
+                example,
+            } => {
+                db.add_grammar(&pattern, &meaning, &level, example.as_deref())
+                    .await?;
+                println!("added grammar: {pattern} = {meaning}");
+            }
+            cli::GrammarAction::List { level } => {
+                let items = db.all_grammar(level.as_deref()).await?;
+                println!("{}", serde_json::to_string_pretty(&items)?);
+            }
+        },
+        Command::Seen {
+            word,
+            quality,
+            grammar,
+        } => {
+            if grammar {
+                srs::record_grammar_review(&db, &word, quality).await?;
+                println!("recorded grammar review: {word} quality={quality}");
+            } else {
+                srs::record_review(&db, &word, quality).await?;
+                println!("recorded review: {word} quality={quality}");
+            }
         }
         Command::Review { grammar } => {
             let items = if grammar {
@@ -71,8 +96,8 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
             db.set_config(&key, &value).await?;
             println!("set {key} = {value}");
         }
-        Command::Export { format } => {
-            cli::export::export(&db, &format).await?;
+        Command::Export { format, grammar } => {
+            cli::export::export(&db, &format, grammar).await?;
         }
     }
 

--- a/src/srs.rs
+++ b/src/srs.rs
@@ -14,13 +14,29 @@ use crate::{
 
 /// Record a review for a vocabulary word and update SRS state.
 pub async fn record_review(db: &Database, word: &str, quality: u8) -> Result<()> {
+    let item_id = db.get_vocabulary_id(word).await?;
+    record_review_item(db, item_id, "vocabulary", quality).await
+}
+
+/// Record a review for a grammar pattern and update SRS state.
+pub async fn record_grammar_review(db: &Database, pattern: &str, quality: u8) -> Result<()> {
+    let item_id = db.get_grammar_id(pattern).await?;
+    record_review_item(db, item_id, "grammar", quality).await
+}
+
+/// Shared SRS review logic for both vocabulary and grammar items.
+async fn record_review_item(
+    db: &Database,
+    item_id: i64,
+    item_type: &str,
+    quality: u8,
+) -> Result<()> {
     ensure!(
         matches!(quality, 1 | 3 | 5),
         error::InvalidQualitySnafu { value: quality }
     );
 
-    let item_id = db.get_vocabulary_id(word).await?;
-    let prev = db.get_latest_review(item_id, "vocabulary").await?;
+    let prev = db.get_latest_review(item_id, item_type).await?;
 
     let (interval, ease, reps) = prev.map_or_else(
         || first_review(quality),
@@ -29,7 +45,7 @@ pub async fn record_review(db: &Database, word: &str, quality: u8) -> Result<()>
         },
     );
 
-    db.insert_review(item_id, "vocabulary", quality, interval, ease, reps)
+    db.insert_review(item_id, item_type, quality, interval, ease, reps)
         .await
 }
 


### PR DESCRIPTION
Closes #8

## Summary
- Add `kotoba grammar add/list` commands
- Add `--grammar` flag to `seen` and `export` commands
- Generalize SRS `record_review` to support both vocabulary and grammar
- Add `GrammarNotFound` error variant
- Add `add_grammar`, `get_grammar_id`, `all_grammar` DB methods

## Test plan
- [x] `cargo check` passes
- [x] `cargo clippy` clean
- [x] `cargo test` passes