### PR TITLE
chore(infra): harden .gitignore and justfile (#39)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,31 @@
+# Rust / Cargo
 /target
+**/*.rs.bk
+
+# Build output
+/bin
+
+# Worktrees
+/.worktrees
+
+# Environment
+.env
+.env.*
+
+# OS
+.DS_Store
+Thumbs.db
+Desktop.ini
+
+# IDEs
+.vscode/
+.idea/
+*.iml
+*.swp
+*.swo
+*~
+
+# Coverage / profiling
+*.profraw
+lcov.info
+tarpaulin-report.html

--- a/justfile
+++ b/justfile
@@ -66,12 +66,9 @@ build-release:
 # Run all pre-commit checks
 pre-commit: fmt-check lint test
 
-# Install git hooks
+# Install git hooks via prek
 setup-hooks:
-    @echo '#!/usr/bin/env bash' > .git/hooks/pre-commit
-    @echo 'just pre-commit' >> .git/hooks/pre-commit
-    @chmod +x .git/hooks/pre-commit
-    @echo "Pre-commit hook installed."
+    prek install
 
 # ─── Changelog & Release ─────────────────────────────────────────────
 


### PR DESCRIPTION
Closes #39

## Changes

- **`.gitignore`**: expanded from just `/target` to cover OS files (`.DS_Store`, `Thumbs.db`), IDE files (`.vscode/`, `.idea/`, vim swap), build output (`/bin`), worktrees (`/.worktrees`), env files (`.env*`), and coverage/profiling artifacts
- **`justfile`**: replaced manual hook script in `setup-hooks` with `prek install`