### PR TITLE
feat(cli): add download progress bars and structured JSON output (#42)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,6 +353,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -574,6 +587,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -740,6 +759,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -759,6 +789,7 @@ checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -1161,6 +1192,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+ "web-time",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1247,6 +1291,8 @@ dependencies = [
  "chrono",
  "clap",
  "dirs",
+ "futures-util",
+ "indicatif",
  "ndarray",
  "ort",
  "reqwest",
@@ -1528,6 +1574,12 @@ dependencies = [
  "autocfg",
  "libm",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "once_cell"
@@ -1976,6 +2028,7 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-core",
+ "futures-util",
  "h2",
  "http",
  "http-body",
@@ -1998,12 +2051,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
 ]
 
@@ -2989,6 +3044,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3209,6 +3270,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3383,6 +3457,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,9 @@ bon = "3"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
 dirs = "6"
-reqwest = { version = "0.13", features = ["json", "query"] }
+futures-util = "0.3"
+indicatif = "0.17"
+reqwest = { version = "0.13", features = ["json", "query", "stream"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 snafu = "0.9"

--- a/deny.toml
+++ b/deny.toml
@@ -3,7 +3,10 @@ all-features = true
 
 [advisories]
 version = 2
-ignore = []
+ignore = [
+    # number_prefix is a transitive dep of indicatif; unmaintained but no security issue
+    "RUSTSEC-2025-0119",
+]
 
 [licenses]
 version = 2

--- a/src/cli/setup.rs
+++ b/src/cli/setup.rs
@@ -1,7 +1,10 @@
 //! `kotoba setup` — download VOICEVOX Engine and initialize environment.
 
-use std::path::PathBuf;
+use std::{io::Write, path::PathBuf};
 
+use futures_util::StreamExt;
+use indicatif::{ProgressBar, ProgressStyle};
+use serde::Serialize;
 use snafu::ResultExt;
 
 use crate::{
@@ -10,6 +13,15 @@ use crate::{
 };
 
 const VOICEVOX_VERSION: &str = "0.22.2";
+
+/// Result of running the setup command.
+#[derive(Debug, Serialize)]
+pub struct SetupResult {
+    /// Path to the database file.
+    pub db_path:            String,
+    /// Whether VOICEVOX Engine is installed after setup.
+    pub voicevox_installed: bool,
+}
 
 fn voicevox_dir() -> Result<PathBuf> {
     let dir = dirs::home_dir()
@@ -50,13 +62,13 @@ pub fn is_voicevox_installed() -> Result<bool> {
 pub fn voicevox_executable() -> Result<PathBuf> { Ok(voicevox_dir()?.join("run")) }
 
 /// Run full setup: download VOICEVOX Engine + initialize DB.
-pub async fn run(db: &Database) -> Result<()> {
-    println!("initializing database...");
+pub async fn run(db: &Database) -> Result<SetupResult> {
+    eprintln!("initializing database...");
     db.init().await?;
-    println!("  database ready at {}", db.path().display());
+    eprintln!("  database ready at {}", db.path().display());
 
     if is_voicevox_installed()? {
-        println!("  voicevox engine already installed");
+        eprintln!("  voicevox engine already installed");
     } else {
         download_voicevox().await?;
     }
@@ -64,16 +76,20 @@ pub async fn run(db: &Database) -> Result<()> {
     db.set_config("tts_backend", "voicevox").await?;
     db.set_config("voicevox_speaker", "1").await?;
 
-    println!("setup complete!");
-    Ok(())
+    eprintln!("setup complete!");
+
+    Ok(SetupResult {
+        db_path:            db.path().display().to_string(),
+        voicevox_installed: is_voicevox_installed()?,
+    })
 }
 
 async fn download_voicevox() -> Result<()> {
     let url = voicevox_download_url();
     let dir = voicevox_dir()?;
 
-    println!("  downloading voicevox engine {VOICEVOX_VERSION}...");
-    println!("  url: {url}");
+    eprintln!("  downloading voicevox engine {VOICEVOX_VERSION}...");
+    eprintln!("  url: {url}");
 
     let client = reqwest::Client::new();
     let response = client.get(&url).send().await.context(error::HttpSnafu)?;
@@ -85,11 +101,33 @@ async fn download_voicevox() -> Result<()> {
         .build());
     }
 
-    let bytes = response.bytes().await.context(error::HttpSnafu)?;
+    let total_size = response.content_length().unwrap_or(0);
+
+    let pb = ProgressBar::new(total_size);
+    pb.set_style(
+        ProgressStyle::default_bar()
+            .template(
+                "{bar:40.cyan/blue} {percent}% {bytes}/{total_bytes}  {bytes_per_sec}  ETA {eta}",
+            )
+            .expect("valid progress bar template")
+            .progress_chars("=>-"),
+    );
 
     let tmp = dir.with_extension("tmp");
     std::fs::create_dir_all(tmp.parent().expect("parent dir")).context(error::IoSnafu)?;
-    std::fs::write(&tmp, &bytes).context(error::IoSnafu)?;
+
+    // Stream the response body to disk in chunks instead of buffering the
+    // entire archive in memory.
+    let mut stream = response.bytes_stream();
+    let mut file = std::fs::File::create(&tmp).context(error::IoSnafu)?;
+
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.context(error::HttpSnafu)?;
+        file.write_all(&chunk).context(error::IoSnafu)?;
+        pb.inc(chunk.len() as u64);
+    }
+
+    pb.finish_and_clear();
 
     // Extract .vvpp archive (zip format)
     let file = std::fs::File::open(&tmp).context(error::IoSnafu)?;
@@ -124,6 +162,6 @@ async fn download_voicevox() -> Result<()> {
         }
     }
 
-    println!("  voicevox engine installed at {}", dir.display());
+    eprintln!("  voicevox engine installed at {}", dir.display());
     Ok(())
 }

--- a/src/cli/voice.rs
+++ b/src/cli/voice.rs
@@ -1,7 +1,9 @@
 //! `kotoba voice` — manage TTS voice models.
 
-use std::path::PathBuf;
+use std::{io::Write, path::PathBuf};
 
+use futures_util::StreamExt;
+use indicatif::{ProgressBar, ProgressStyle};
 use serde::Serialize;
 use snafu::ResultExt;
 
@@ -16,6 +18,15 @@ pub struct VoiceInfo {
     pub name:    String,
     pub backend: String,
     pub active:  bool,
+}
+
+/// Result of adding a voice model.
+#[derive(Debug, Serialize)]
+pub struct VoiceAddResult {
+    /// The model identifier (directory name).
+    pub model: String,
+    /// Filesystem path where the model was saved.
+    pub path:  String,
 }
 
 fn models_dir() -> Result<PathBuf> {
@@ -83,22 +94,25 @@ pub async fn list(db: &Database) -> Result<()> {
 /// Set the active voice.
 pub async fn set(db: &Database, name: &str) -> Result<()> {
     db.set_config("voice", name).await?;
-    println!("voice set to: {name}");
+    eprintln!("voice set to: {name}");
     Ok(())
 }
 
 /// Download a voice model from `HuggingFace`.
-pub async fn add(repo_id: &str) -> Result<()> {
+pub async fn add(repo_id: &str) -> Result<VoiceAddResult> {
     let models_path = models_dir()?;
     let model_name = repo_id.split('/').next_back().unwrap_or(repo_id);
     let model_dir = models_path.join(model_name);
 
     if model_dir.exists() {
-        println!("model already downloaded: {}", model_dir.display());
-        return Ok(());
+        eprintln!("model already downloaded: {}", model_dir.display());
+        return Ok(VoiceAddResult {
+            model: model_name.to_string(),
+            path:  model_dir.display().to_string(),
+        });
     }
 
-    println!("downloading model from huggingface: {repo_id}...");
+    eprintln!("downloading model from huggingface: {repo_id}...");
 
     // Download model.onnx from HuggingFace
     let client = reqwest::Client::new();
@@ -117,10 +131,33 @@ pub async fn add(repo_id: &str) -> Result<()> {
         .build());
     }
 
-    let bytes = response.bytes().await.context(error::HttpSnafu)?;
+    let total_size = response.content_length().unwrap_or(0);
+
+    let pb = ProgressBar::new(total_size);
+    pb.set_style(
+        ProgressStyle::default_bar()
+            .template(
+                "{bar:40.cyan/blue} {percent}% {bytes}/{total_bytes}  {bytes_per_sec}  ETA {eta}",
+            )
+            .expect("valid progress bar template")
+            .progress_chars("=>-"),
+    );
 
     std::fs::create_dir_all(&model_dir).context(error::IoSnafu)?;
-    std::fs::write(model_dir.join("model.onnx"), &bytes).context(error::IoSnafu)?;
+
+    // Stream the response body to disk in chunks instead of buffering the
+    // entire model file in memory.
+    let mut stream = response.bytes_stream();
+    let model_path = model_dir.join("model.onnx");
+    let mut file = std::fs::File::create(&model_path).context(error::IoSnafu)?;
+
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.context(error::HttpSnafu)?;
+        file.write_all(&chunk).context(error::IoSnafu)?;
+        pb.inc(chunk.len() as u64);
+    }
+
+    pb.finish_and_clear();
 
     // Try to download config.json if available
     let config_url = format!("https://huggingface.co/{repo_id}/resolve/main/config.json");
@@ -131,8 +168,11 @@ pub async fn add(repo_id: &str) -> Result<()> {
         let _ = std::fs::write(model_dir.join("config.json"), &config_bytes);
     }
 
-    println!("model saved to: {}", model_dir.display());
-    println!("use `kotoba voice set vits:{model_name}` to activate");
+    eprintln!("model saved to: {}", model_dir.display());
+    eprintln!("use `kotoba voice set vits:{model_name}` to activate");
 
-    Ok(())
+    Ok(VoiceAddResult {
+        model: model_name.to_string(),
+        path:  model_dir.display().to_string(),
+    })
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,8 +11,7 @@ use clap::Parser;
 use cli::{Cli, Command};
 
 #[tokio::main]
-#[allow(clippy::too_many_lines)]
-async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
+async fn main() {
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::from_default_env()
@@ -20,6 +19,18 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         )
         .init();
 
+    if let Err(e) = run().await {
+        eprintln!("Error: {e}");
+        println!(
+            "{}",
+            serde_json::json!({"ok": false, "error": e.to_string()})
+        );
+        std::process::exit(1);
+    }
+}
+
+#[allow(clippy::too_many_lines)]
+async fn run() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
     let db = db::Database::open_default().await?;
 
@@ -31,7 +42,11 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     match cli.command {
         Command::Init => {
             db.init().await?;
-            println!("kotoba initialized at {}", db.path().display());
+            eprintln!("kotoba initialized at {}", db.path().display());
+            println!(
+                "{}",
+                serde_json::json!({"ok": true, "action": "init", "path": db.path().display().to_string()})
+            );
         }
         Command::Status => {
             let status = db.status().await?;
@@ -44,7 +59,11 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
             level,
         } => {
             db.add_vocabulary(&word, &reading, &meaning, &level).await?;
-            println!("added: {word}({reading}) = {meaning}");
+            eprintln!("added: {word}({reading}) = {meaning}");
+            println!(
+                "{}",
+                serde_json::json!({"ok": true, "action": "add", "word": word, "reading": reading, "meaning": meaning})
+            );
         }
         Command::Grammar { action } => match action {
             cli::GrammarAction::Add {
@@ -55,7 +74,11 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
             } => {
                 db.add_grammar(&pattern, &meaning, &level, example.as_deref())
                     .await?;
-                println!("added grammar: {pattern} = {meaning}");
+                eprintln!("added grammar: {pattern} = {meaning}");
+                println!(
+                    "{}",
+                    serde_json::json!({"ok": true, "action": "grammar_add", "pattern": pattern, "meaning": meaning})
+                );
             }
             cli::GrammarAction::List { level } => {
                 let items = db.all_grammar(level.as_deref()).await?;
@@ -69,11 +92,15 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         } => {
             if grammar {
                 srs::record_grammar_review(&db, &word, quality).await?;
-                println!("recorded grammar review: {word} quality={quality}");
+                eprintln!("recorded grammar review: {word} quality={quality}");
             } else {
                 srs::record_review(&db, &word, quality).await?;
-                println!("recorded review: {word} quality={quality}");
+                eprintln!("recorded review: {word} quality={quality}");
             }
+            println!(
+                "{}",
+                serde_json::json!({"ok": true, "action": "seen", "word": word, "quality": quality, "grammar": grammar})
+            );
         }
         Command::Review { grammar } => {
             let items = if grammar {
@@ -89,10 +116,17 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         }
         Command::Play { word } => {
             let path = cli::play::play_word(&db, &word).await?;
-            println!("{}", path.display());
+            println!(
+                "{}",
+                serde_json::json!({"ok": true, "action": "play", "path": path.display().to_string()})
+            );
         }
         Command::Setup => {
-            cli::setup::run(&db).await?;
+            let result = cli::setup::run(&db).await?;
+            println!(
+                "{}",
+                serde_json::json!({"ok": true, "action": "setup", "db_path": result.db_path, "voicevox_installed": result.voicevox_installed})
+            );
         }
         Command::Doctor => {
             cli::doctor::run(&db).await?;
@@ -103,25 +137,46 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
             }
             cli::VoiceAction::Set { name } => {
                 cli::voice::set(&db, &name).await?;
+                println!(
+                    "{}",
+                    serde_json::json!({"ok": true, "action": "voice_set", "name": name})
+                );
             }
             cli::VoiceAction::Add { repo_id } => {
-                cli::voice::add(&repo_id).await?;
+                let result = cli::voice::add(&repo_id).await?;
+                println!(
+                    "{}",
+                    serde_json::json!({"ok": true, "action": "voice_add", "model": result.model, "path": result.path})
+                );
             }
         },
         Command::Config { action } => match action {
             cli::ConfigAction::Set { key, value } => {
                 db.set_config(&key, &value).await?;
-                println!("set {key} = {value}");
+                eprintln!("set {key} = {value}");
+                println!(
+                    "{}",
+                    serde_json::json!({"ok": true, "action": "config_set", "key": key, "value": value})
+                );
             }
             cli::ConfigAction::Get { key } => {
                 let value = db.get_config(&key).await?;
-                println!("{}", value.as_deref().unwrap_or("(not set)"));
+                let display_value = value.as_deref().unwrap_or("(not set)");
+                println!(
+                    "{}",
+                    serde_json::json!({"ok": true, "action": "config_get", "key": key, "value": display_value})
+                );
             }
             cli::ConfigAction::List => {
                 let entries = db.all_config().await?;
-                for (key, value) in entries {
-                    println!("{key} = {value}");
-                }
+                let map: serde_json::Map<String, serde_json::Value> = entries
+                    .into_iter()
+                    .map(|(k, v)| (k, serde_json::Value::String(v)))
+                    .collect();
+                println!(
+                    "{}",
+                    serde_json::json!({"ok": true, "action": "config_list", "entries": map})
+                );
             }
         },
         Command::Export { format, grammar } => {


### PR DESCRIPTION
Closes #42

## Changes

### Download progress bars
- `kotoba setup`: VOICEVOX engine download (1.5GB) now streams with progress bar showing bytes/speed/ETA
- `kotoba voice add`: Model downloads also show progress
- Uses `indicatif` crate, progress bars go to stderr

### Structured JSON output
- All commands now output structured JSON to **stdout** (e.g. `{"ok":true,"action":"add","word":"..."}`)
- Human-readable messages go to **stderr** via `eprintln!`
- Errors output as `{"ok":false,"error":"..."}`
- Commands already outputting JSON (status, review, doctor, export) unchanged
- LLMs calling kotoba can now reliably parse all command results

### Error handling
- Extracted `main()` body into `run()` for clean error-to-JSON conversion