### PR TITLE
feat(voice): wire VITS ONNX inference into play command (#45)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,3 +8,4 @@ pub mod paths;
 pub mod romaji;
 pub mod srs;
 pub mod store;
+pub mod vits;


### PR DESCRIPTION
Closes #45

## Summary
- Replace `synthesize_vits` placeholder with real call to `crate::vits::synthesize(model_name, text, output_path)`
- Add `Vits` error variant to `KotobaError` wrapping `VitsError` via snafu
- Export `vits` module from `lib.rs`, remove `#[allow(dead_code)]` from `main.rs`

## Test plan
- [x] `cargo check` passes
- [x] `cargo test` — 44 tests pass (including all vits unit tests)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)