### PR TITLE
feat(cli): wire VITS ONNX inference into play command (#52)

### DIFF
--- a/src/cli/play.rs
+++ b/src/cli/play.rs
@@ -65,7 +65,7 @@ pub async fn play_word(db: &Database, word: &str) -> Result<PathBuf> {
 
     match config.backend.as_str() {
         "voicevox" => synthesize_voicevox(word, &config.speaker_id, &file).await?,
-        "vits" => synthesize_vits()?,
+        "vits" => synthesize_vits(&config.speaker_id, word, &file).await?,
         other => {
             return Err(error::VoicevoxSnafu {
                 message: format!("unknown voice backend: {other}"),
@@ -127,12 +127,19 @@ async fn synthesize_voicevox(word: &str, speaker_id: &str, out_path: &PathBuf) -
     Ok(())
 }
 
-/// Placeholder for VITS inference — will be implemented in Issue #12.
-fn synthesize_vits() -> Result<()> {
-    Err(error::VoicevoxSnafu {
-        message: "VITS inference not yet implemented".to_string(),
-    }
-    .build())
+/// Synthesize audio using local VITS ONNX inference.
+async fn synthesize_vits(model_name: &str, word: &str, out_path: &std::path::Path) -> Result<()> {
+    crate::vits::synthesize(model_name, word, out_path)
+        .await
+        .map_err(|e| match e {
+            crate::vits::VitsError::ModelNotFound { path } => {
+                error::ModelNotFoundSnafu { name: path }.build()
+            }
+            other => error::VoicevoxSnafu {
+                message: other.to_string(),
+            }
+            .build(),
+        })
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,6 @@ mod error;
 mod romaji;
 mod srs;
 mod store;
-#[allow(dead_code)] // not yet wired into play.rs — integration pending branch merge
 mod vits;
 
 use clap::Parser;

--- a/src/vits.rs
+++ b/src/vits.rs
@@ -27,6 +27,10 @@ pub enum VitsError {
     /// Blocking task join error.
     #[snafu(display("join error: {source}"))]
     Join { source: tokio::task::JoinError },
+
+    /// Home directory could not be determined.
+    #[snafu(display("home directory not found"))]
+    HomeNotFound,
 }
 
 /// Module-level result type.
@@ -161,7 +165,7 @@ fn kana_to_ascii(text: &str) -> String {
 /// The inference runs inside `spawn_blocking` to avoid blocking the
 /// async runtime.
 pub async fn synthesize(model_name: &str, text: &str, output: &Path) -> Result<()> {
-    let home = dirs::home_dir().expect("home directory must exist");
+    let home = dirs::home_dir().ok_or_else(|| HomeNotFoundSnafu.build())?;
     let model_path = home
         .join(".kotoba")
         .join("models")


### PR DESCRIPTION
Closes #52

- Remove `#[allow(dead_code)]` from vits module
- Connect `vits::synthesize()` to play command's VITS backend
- Fix `expect()` in vits.rs with proper `HomeNotFound` error variant