### PR TITLE
feat(cli): CSV quoting, DB indexes, list command, and CLI polish (#53)

### DIFF
--- a/src/cli/export.rs
+++ b/src/cli/export.rs
@@ -7,6 +7,10 @@ use crate::{
     error::{self, Result},
 };
 
+/// Escape a field for RFC 4180 CSV output by wrapping in double quotes and
+/// doubling any internal quote characters.
+fn csv_field(s: &str) -> String { format!("\"{}\"", s.replace('"', "\"\"")) }
+
 /// Export vocabulary or grammar in the specified format to stdout.
 pub async fn export(db: &Database, format: &str, grammar: bool) -> Result<()> {
     ensure!(
@@ -22,7 +26,7 @@ pub async fn export(db: &Database, format: &str, grammar: bool) -> Result<()> {
 }
 
 async fn export_vocabulary(db: &Database, format: &str) -> Result<()> {
-    let vocab = db.all_vocabulary().await?;
+    let vocab = db.all_vocabulary(None).await?;
 
     match format {
         "json" => {
@@ -34,7 +38,11 @@ async fn export_vocabulary(db: &Database, format: &str) -> Result<()> {
             for v in &vocab {
                 println!(
                     "{},{},{},{},{}",
-                    v.word, v.reading, v.romaji, v.meaning, v.level
+                    csv_field(&v.word),
+                    csv_field(&v.reading),
+                    csv_field(&v.romaji),
+                    csv_field(&v.meaning),
+                    csv_field(&v.level),
                 );
             }
         }
@@ -62,10 +70,10 @@ async fn export_grammar(db: &Database, format: &str) -> Result<()> {
             for g in &items {
                 println!(
                     "{},{},{},{}",
-                    g.pattern,
-                    g.meaning,
-                    g.level,
-                    g.example.as_deref().unwrap_or("")
+                    csv_field(&g.pattern),
+                    csv_field(&g.meaning),
+                    csv_field(&g.level),
+                    csv_field(g.example.as_deref().unwrap_or("")),
                 );
             }
         }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -81,6 +81,15 @@ pub enum Command {
         #[command(subcommand)]
         action: ConfigAction,
     },
+    /// List vocabulary or grammar entries
+    List {
+        /// List grammar instead of vocabulary
+        #[arg(long)]
+        grammar: bool,
+        /// Filter by JLPT level
+        #[arg(long)]
+        level:   Option<String>,
+    },
     /// Export vocabulary or grammar data
     Export {
         /// Format: json, csv, anki

--- a/src/cli/play.rs
+++ b/src/cli/play.rs
@@ -60,8 +60,11 @@ pub async fn play_word(db: &Database, word: &str) -> Result<PathBuf> {
     ));
 
     if file.exists() {
+        eprintln!("using cached: {}", file.display());
         return Ok(file);
     }
+
+    eprintln!("synthesizing: {word}...");
 
     match config.backend.as_str() {
         "voicevox" => synthesize_voicevox(word, &config.speaker_id, &file).await?,
@@ -73,6 +76,8 @@ pub async fn play_word(db: &Database, word: &str) -> Result<PathBuf> {
             .build());
         }
     }
+
+    eprintln!("cached: {}", file.display());
 
     Ok(file)
 }

--- a/src/cli/setup.rs
+++ b/src/cli/setup.rs
@@ -31,7 +31,7 @@ fn voicevox_dir() -> Result<PathBuf> {
     Ok(dir)
 }
 
-fn voicevox_download_url() -> String {
+fn voicevox_download_url(version: &str) -> String {
     // macOS assets: voicevox_engine-macos-{arch}-{ver}.vvpp (no -cpu suffix)
     // Linux/Windows: voicevox_engine-{os}-cpu-{ver}.vvpp (no arch, has -cpu)
     let platform = if cfg!(target_os = "macos") {
@@ -48,7 +48,7 @@ fn voicevox_download_url() -> String {
     };
 
     format!(
-        "https://github.com/VOICEVOX/voicevox_engine/releases/download/{VOICEVOX_VERSION}/voicevox_engine-{platform}-{VOICEVOX_VERSION}.vvpp"
+        "https://github.com/VOICEVOX/voicevox_engine/releases/download/{version}/voicevox_engine-{platform}-{version}.vvpp"
     )
 }
 
@@ -67,14 +67,25 @@ pub async fn run(db: &Database) -> Result<SetupResult> {
     db.init().await?;
     eprintln!("  database ready at {}", db.path().display());
 
+    let version = db
+        .get_config("voicevox_version")
+        .await?
+        .unwrap_or_else(|| VOICEVOX_VERSION.to_string());
+
     if is_voicevox_installed()? {
         eprintln!("  voicevox engine already installed");
     } else {
-        download_voicevox().await?;
+        download_voicevox(&version).await?;
     }
 
-    db.set_config("tts_backend", "voicevox").await?;
-    db.set_config("voicevox_speaker", "1").await?;
+    // Only set voice defaults if not already configured, so re-running setup
+    // does not overwrite user customizations.
+    if db.get_config("tts_backend").await?.is_none() {
+        db.set_config("tts_backend", "voicevox").await?;
+    }
+    if db.get_config("voicevox_speaker").await?.is_none() {
+        db.set_config("voicevox_speaker", "1").await?;
+    }
 
     eprintln!("setup complete!");
 
@@ -84,11 +95,11 @@ pub async fn run(db: &Database) -> Result<SetupResult> {
     })
 }
 
-async fn download_voicevox() -> Result<()> {
-    let url = voicevox_download_url();
+async fn download_voicevox(version: &str) -> Result<()> {
+    let url = voicevox_download_url(version);
     let dir = voicevox_dir()?;
 
-    eprintln!("  downloading voicevox engine {VOICEVOX_VERSION}...");
+    eprintln!("  downloading voicevox engine {version}...");
     eprintln!("  url: {url}");
 
     let client = reqwest::Client::new();

--- a/src/db.rs
+++ b/src/db.rs
@@ -351,13 +351,27 @@ impl Database {
             .build())
     }
 
-    /// Return all vocabulary items for export.
-    pub async fn all_vocabulary(&self) -> Result<Vec<VocabularyItem>> {
-        let rows: Vec<(String, String, String, String, String)> = sqlx::query_as(
-            "SELECT word, reading, romaji, meaning, level FROM vocabulary ORDER BY created_at",
-        )
-        .fetch_all(self.pool())
-        .await
+    /// Return all vocabulary items, optionally filtered by JLPT level.
+    pub async fn all_vocabulary(&self, level: Option<&str>) -> Result<Vec<VocabularyItem>> {
+        let rows: Vec<(String, String, String, String, String)> = match level {
+            Some(lvl) => {
+                sqlx::query_as(
+                    "SELECT word, reading, romaji, meaning, level FROM vocabulary WHERE level = ? \
+                     ORDER BY created_at",
+                )
+                .bind(lvl)
+                .fetch_all(self.pool())
+                .await
+            }
+            None => {
+                sqlx::query_as(
+                    "SELECT word, reading, romaji, meaning, level FROM vocabulary ORDER BY \
+                     created_at",
+                )
+                .fetch_all(self.pool())
+                .await
+            }
+        }
         .context(error::SqlxSnafu)?;
 
         Ok(rows

--- a/src/main.rs
+++ b/src/main.rs
@@ -178,6 +178,15 @@ async fn run() -> std::result::Result<(), Box<dyn std::error::Error>> {
                 );
             }
         },
+        Command::List { grammar, level } => {
+            if grammar {
+                let items = db.all_grammar(level.as_deref()).await?;
+                println!("{}", serde_json::to_string_pretty(&items)?);
+            } else {
+                let items = db.all_vocabulary(level.as_deref()).await?;
+                println!("{}", serde_json::to_string_pretty(&items)?);
+            }
+        }
         Command::Export { format, grammar } => {
             cli::export::export(&db, &format, grammar).await?;
         }

--- a/src/schema.sql
+++ b/src/schema.sql
@@ -28,6 +28,9 @@ CREATE TABLE IF NOT EXISTS reviews (
     reps INTEGER NOT NULL
 );
 
+CREATE INDEX IF NOT EXISTS idx_reviews_item ON reviews (item_id, item_type);
+CREATE INDEX IF NOT EXISTS idx_reviews_reviewed_at ON reviews (reviewed_at);
+
 CREATE TABLE IF NOT EXISTS user_profile (
     key TEXT PRIMARY KEY,
     value TEXT NOT NULL

--- a/tests/export.rs
+++ b/tests/export.rs
@@ -9,7 +9,10 @@ async fn vocabulary_export_has_all_fields() {
         .await
         .expect("add failed");
 
-    let items = db.all_vocabulary().await.expect("all_vocabulary failed");
+    let items = db
+        .all_vocabulary(None)
+        .await
+        .expect("all_vocabulary failed");
     assert_eq!(items.len(), 1);
 
     let v = &items[0];
@@ -44,7 +47,10 @@ async fn vocabulary_export_serializes_to_json() {
         .await
         .expect("add failed");
 
-    let items = db.all_vocabulary().await.expect("all_vocabulary failed");
+    let items = db
+        .all_vocabulary(None)
+        .await
+        .expect("all_vocabulary failed");
     let json = serde_json::to_string(&items).expect("serialization failed");
     assert!(json.contains("\"word\":\"猫\""));
     assert!(json.contains("\"romaji\":\"neko\""));

--- a/tests/vocabulary_flow.rs
+++ b/tests/vocabulary_flow.rs
@@ -11,7 +11,10 @@ async fn add_and_retrieve_vocabulary() {
         .await
         .expect("add_vocabulary failed");
 
-    let items = db.all_vocabulary().await.expect("all_vocabulary failed");
+    let items = db
+        .all_vocabulary(None)
+        .await
+        .expect("all_vocabulary failed");
     assert_eq!(items.len(), 1);
     assert_eq!(items[0].word, "食べる");
     assert_eq!(items[0].reading, "たべる");
@@ -26,7 +29,10 @@ async fn romaji_auto_generated_on_add() {
         .await
         .expect("add_vocabulary failed");
 
-    let items = db.all_vocabulary().await.expect("all_vocabulary failed");
+    let items = db
+        .all_vocabulary(None)
+        .await
+        .expect("all_vocabulary failed");
     assert_eq!(items[0].romaji, romaji::to_romaji("のむ"));
     assert_eq!(items[0].romaji, "nomu");
 }
@@ -41,7 +47,10 @@ async fn duplicate_word_replaces_entry() {
         .await
         .expect("second add failed");
 
-    let items = db.all_vocabulary().await.expect("all_vocabulary failed");
+    let items = db
+        .all_vocabulary(None)
+        .await
+        .expect("all_vocabulary failed");
     assert_eq!(items.len(), 1, "duplicate should replace, not insert");
     assert_eq!(items[0].meaning, "dog (pet)");
     assert_eq!(items[0].level, "N4");
@@ -67,6 +76,9 @@ async fn multiple_vocabulary_entries() {
         .await
         .expect("add failed");
 
-    let items = db.all_vocabulary().await.expect("all_vocabulary failed");
+    let items = db
+        .all_vocabulary(None)
+        .await
+        .expect("all_vocabulary failed");
     assert_eq!(items.len(), 3);
 }


### PR DESCRIPTION
Closes #53

- Quote CSV export fields (RFC 4180) to handle commas in data
- Add indexes on reviews table for query performance
- Preserve voice config when re-running setup
- Add `kotoba list` command with `--grammar` and `--level` flags
- Show synthesis progress in play command (stderr)
- Allow VOICEVOX version override via config